### PR TITLE
Fixed ItemParser bug

### DIFF
--- a/src/helpers/ItemParser.ts
+++ b/src/helpers/ItemParser.ts
@@ -154,7 +154,7 @@ export class ItemParser {
                 Guardian:'4ade7faa-4cf1-8376-95ef-39884480959b',
                 Marshal:'c4883e50-4494-202c-3ec3-6b8a9284f00b',
                 Spectre:'462080d1-4035-2937-7c09-27aa2a5c27a7',
-                Stringer:'f7e1b454-4ad4-1063-ec0a-159e56b58941',
+                Stinger:'f7e1b454-4ad4-1063-ec0a-159e56b58941',
                 Melee:'2f59173c-4bed-b6c3-2191-dea9b58be9c7',
             }
             const GunSkins = {};

--- a/src/helpers/ItemParser.ts
+++ b/src/helpers/ItemParser.ts
@@ -137,27 +137,29 @@ export class ItemParser {
             const guns = this.data.Guns;
             const playerCard = this.data.PlayerCard;
             const playerTitle = this.data.PlayerTitle;
-            const GunSkins = {
-                Odin: guns.substr(guns.indexOf('63e6c2b6-4a8e-869c-3d4c-e38355226584')+48, 36),
-                Ares: guns.substr(guns.indexOf('55d8a0f4-4274-ca67-fe2c-06ab45efdf58')+48, 36),
-                Vandal: guns.substr(guns.indexOf('9c82e19d-4575-0200-1a81-3eacf00cf872')+48, 36),
-                Bulldog: guns.substr(guns.indexOf('ae3de142-4d85-2547-dd26-4e90bed35cf7')+48, 36),
-                Phantom: guns.substr(guns.indexOf('ee8e8d15-496b-07ac-e5f6-8fae5d4c7b1a')+48, 36),
-                Judge: guns.substr(guns.indexOf('ec845bf4-4f79-ddda-a3da-0db3774b2794')+48, 36),
-                Bucky: guns.substr(guns.indexOf('910be174-449b-c412-ab22-d0873436b21b')+48, 36),
-                Frenzy: guns.substr(guns.indexOf('44d4e95c-4157-0037-81b2-17841bf2e8e3')+48, 36),
-                Classic: guns.substr(guns.indexOf('29a0cfab-485b-f5d5-779a-b59f85e204a8')+48, 36),
-                Ghost: guns.substr(guns.indexOf('1baa85b4-4c70-1284-64bb-6481dfc3bb4e')+48, 36),
-                Sheriff: guns.substr(guns.indexOf('e336c6b8-418d-9340-d77f-7a9e4cfe0702')+48, 36),
-                Shorty: guns.substr(guns.indexOf('42da8ccc-40d5-affc-beec-15aa47b42eda')+48, 36),
-                Operator: guns.substr(guns.indexOf('a03b24d3-4319-996d-0f8c-94bbfba1dfc7')+48, 36),
-                Guardian: guns.substr(guns.indexOf('4ade7faa-4cf1-8376-95ef-39884480959b')+48, 36),
-                Marshal: guns.substr(guns.indexOf('c4883e50-4494-202c-3ec3-6b8a9284f00b')+48, 36),
-                Spectre: guns.substr(guns.indexOf('462080d1-4035-2937-7c09-27aa2a5c27a7')+48, 36),
-                Stinger: guns.substr(guns.indexOf('f7e1b454-4ad4-1063-ec0a-159e56b58941')+48, 36),
-                Melee: guns.substr(guns.indexOf('2F59173C-4BED-B6C3-2191-DEA9B58BE9C7')+48, 36),
+            const GunIDs = {
+                Odin: '63e6c2b6-4a8e-869c-3d4c-e38355226584',
+                Ares: '55d8a0f4-4274-ca67-fe2c-06ab45efdf58',
+                Vandal: '9c82e19d-4575-0200-1a81-3eacf00cf872',
+                Bulldog:'ae3de142-4d85-2547-dd26-4e90bed35cf7',
+                Phantom:'ee8e8d15-496b-07ac-e5f6-8fae5d4c7b1a',
+                Judge:'ec845bf4-4f79-ddda-a3da-0db3774b2794',
+                Bucky:'910be174-449b-c412-ab22-d0873436b21b',
+                Frenzy:'44d4e95c-4157-0037-81b2-17841bf2e8e3',
+                Classic:'29a0cfab-485b-f5d5-779a-b59f85e204a8',
+                Ghost:'1baa85b4-4c70-1284-64bb-6481dfc3bb4e',
+                Sheriff:'e336c6b8-418d-9340-d77f-7a9e4cfe0702',
+                Shorty:'42da8ccc-40d5-affc-beec-15aa47b42eda',
+                Operator:'a03b24d3-4319-996d-0f8c-94bbfba1dfc7',
+                Guardian:'4ade7faa-4cf1-8376-95ef-39884480959b',
+                Marshal:'c4883e50-4494-202c-3ec3-6b8a9284f00b',
+                Spectre:'462080d1-4035-2937-7c09-27aa2a5c27a7',
+                Stringer:'f7e1b454-4ad4-1063-ec0a-159e56b58941',
+                Melee:'2f59173c-4bed-b6c3-2191-dea9b58be9c7',
             }
-
+            const GunSkins = {};
+            for(const GunID in GunIDs)
+                GunSkins[GunID] = guns.find((gun)=> gun.ID === GunIDs[GunID]).SkinID
             const PlayerInventory = {
                 Subject: Subject,
                 Version: Version,


### PR DESCRIPTION
# Bug Fix - `ItemParser` error

The `getInventory(<accountId>)` function in the playerApi service was throwing an error because the `ItemParser` was unable to parse the response data object.

The issue was with the `gun` array in the response being treated as a string. 

Here is the error:

![image](https://user-images.githubusercontent.com/57023357/120649531-7e6ccf80-c49a-11eb-8ea1-b79a0698de53.png)

Looks like the `gun` object is an array and not a string. So I wrote some code to parse that object and get the SkinID from the `gun` object and map it to the right guns.

Here's the returned data from the function after the fix:

![image](https://user-images.githubusercontent.com/57023357/120649089-00102d80-c49a-11eb-8244-ece7b62eb111.png)