### PR TITLE
Updated ItemParser to parse the new playerloadout data schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "valorant.js",
-  "version": "1.6.1",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valorant.js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "API Wrapper for valorant with oauth support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers/ItemParser.ts
+++ b/src/helpers/ItemParser.ts
@@ -135,8 +135,7 @@ export class ItemParser {
             const Subject = this.data.Subject;
             const Version = this.data.Version;
             const guns = this.data.Guns;
-            const playerCard = this.data.PlayerCard;
-            const playerTitle = this.data.PlayerTitle;
+            const Identity = this.data.Identity;
             const GunIDs = {
                 Odin: '63e6c2b6-4a8e-869c-3d4c-e38355226584',
                 Ares: '55d8a0f4-4274-ca67-fe2c-06ab45efdf58',
@@ -161,11 +160,10 @@ export class ItemParser {
             for(const GunID in GunIDs)
                 GunSkins[GunID] = guns.find((gun)=> gun.ID === GunIDs[GunID]).SkinID
             const PlayerInventory = {
-                Subject: Subject,
-                Version: Version,
-                GunSkins: GunSkins,
-                PlayerCard: playerCard["ID"],
-                PlayerTitle: playerTitle["ID"]
+                Subject,
+                Version,
+                GunSkins,
+                Identity
             }
             return PlayerInventory;
         }

--- a/src/helpers/ItemParser.ts
+++ b/src/helpers/ItemParser.ts
@@ -136,6 +136,7 @@ export class ItemParser {
             const Version = this.data.Version;
             const guns = this.data.Guns;
             const Identity = this.data.Identity;
+            const sprays = this.data.Sprays;
             const GunIDs = {
                 Odin: '63e6c2b6-4a8e-869c-3d4c-e38355226584',
                 Ares: '55d8a0f4-4274-ca67-fe2c-06ab45efdf58',
@@ -159,10 +160,20 @@ export class ItemParser {
             const GunSkins = {};
             for(const GunID in GunIDs)
                 GunSkins[GunID] = guns.find((gun)=> gun.ID === GunIDs[GunID]).SkinID
+            const sprayIDs = {
+                PreRound: "0814b2fe-4512-60a4-5288-1fbdcec6ca48",
+                MidRound: "04af080a-4071-487b-61c0-5b9c0cfaac74",
+                PostRound: "5863985e-43ac-b05d-cb2d-139e72970014"
+            }
+            const Sprays ={}
+            for(const sprayID in sprayIDs)
+                Sprays[sprayID] = sprays.find((spray)=> spray.EquipSlotID === sprayIDs[sprayID]).SprayID
+    
             const PlayerInventory = {
                 Subject,
                 Version,
                 GunSkins,
+                Sprays,
                 Identity
             }
             return PlayerInventory;


### PR DESCRIPTION
# `ItemParser` Update to Handle New Format

Riot is sending data to the endpoint `/personalization/v2/players/{accountID}/playerloadout` in a revised format, which broke the old ItemParser implementation. Refer [Issue #16 ](https://github.com/Sprayxe/valorant.js/issues/16).

Here is the new format of data: 

```json
{
  "Subject": "16848a0d-ec55-5e7b-9ad8-6d51c6f2d54e",
  "Version": 344,
  "Guns": [
    {
      "ID": "1-4035-2937-7c09-27aa2a5c27a7",
      "SkinID": "d405272b-4388-578c-e33b-04842496b8c1",
      "SkinLevelID": "4d02d9fa-4cb4-4d87-bdf0-97bd5f960c12",
      "ChromaID": "0bf12530-4abb-8851-0420-199af20c2a2a",
      "CharmInstanceID": "f903bda0-fa8d-4b49-8ae6-ea7ede118eb5",
      "CharmID": "7cf1fc2c-4456-fa8f-b9f6-c9be7092163f",
      "CharmLevelID": "cf194771-4eb6-053e-6c0c-5a80dab14f39",
      "Attachments": []
    },
    { "deleted": "other guns for the sake of this example"},
  ],
  "Sprays": [
    {
      "EquipSlotID": "04af080a-4071-487b-61c0-5b9c0cfaac74",
      "SprayID": "0eb56d06-474d-fbec-372f-069286388bc5",
      "SprayLevelID": null
    },
    {
      "EquipSlotID": "5863985e-43ac-b05d-cb2d-139e72970014",
      "SprayID": "bc8917ee-4e11-0286-ff49-77b1e5b12fcb",
      "SprayLevelID": null
    },
    {
      "EquipSlotID": "0814b2fe-4512-60a4-5288-1fbdcec6ca48",
      "SprayID": "677dc003-4dbf-66a8-9116-4f8d7a9fb8d5",
      "SprayLevelID": null
    }
  ],
  "Identity": {
    "PlayerCardID": "5b27d2de-4a97-d6c1-76e7-669189c67072",
    "PlayerTitleID": "f3bf3c15-4e3b-6e58-64a3-8f9995f39370",
    "AccountLevel": 0
  },
  "Incognito": false
}
```

A new `Identity` property is now present. And it looks like it's returning the new "Account Level" feature Riot is releasing soon ([source](https://twitter.com/ValorLeaks/status/1399903899587334145?s=20))

It is only a minor change, so I made a small refactor in the ItemParser code. It will return the `Identity` object, which contains the PlayerCardID and PlayerTitleID.  (Since this is a refactor, this might break valorant.js dependants - well tbh it's already broken right now). 


Also (off topic), looks like Riot is implementing an "Incognito" feature for Valorant? Inferring this from the last `Incognito`  property. I don't know if this existed before.